### PR TITLE
update to allow AWS LB event target group trigger

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -56,7 +56,9 @@ def make_environ(event):
     environ['REQUEST_METHOD'] = event['httpMethod']
     environ['PATH_INFO'] = event['path']
     environ['QUERY_STRING'] = urlencode(qs) if qs else ''
-    environ['REMOTE_ADDR'] = event['requestContext']['identity']['sourceIp']
+
+    environ['REMOTE_ADDR'] = event['headers']['X-Forwarded-For']
+
     environ['HOST'] = '{}:{}'.format(
         environ.get('HTTP_HOST', ''),
         environ.get('HTTP_X_FORWARDED_PORT', ''),

--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -57,7 +57,7 @@ def make_environ(event):
     environ['PATH_INFO'] = event['path']
     environ['QUERY_STRING'] = urlencode(qs) if qs else ''
 
-    environ['REMOTE_ADDR'] = event['headers']['X-Forwarded-For']
+    environ['REMOTE_ADDR'] = environ.get('X_FORWARDED_FOR')
 
     environ['HOST'] = '{}:{}'.format(
         environ.get('HTTP_HOST', ''),


### PR DESCRIPTION
This sets the REMOTE_ADDR from `headers->x-forwarded-for` instead of the `identity-sourceIp` which have the same value when invoking the lambda via an AWS GATEWAY. This change also allows the lambda to be invoked via a Load Balancer using a target group.