### PR TITLE
Don't assume headers exist in event

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -66,14 +66,14 @@ def make_environ(event):
     environ['SCRIPT_NAME'] = ''
     environ['SERVER_NAME'] = 'SERVER_NAME'
 
-    environ['SERVER_PORT'] = environ['HTTP_X_FORWARDED_PORT']
+    environ['SERVER_PORT'] = environ.get('HTTP_X_FORWARDED_PORT', '')
     environ['SERVER_PROTOCOL'] = 'HTTP/1.1'
 
     environ['CONTENT_LENGTH'] = str(
         len(event['body']) if event['body'] else ''
     )
 
-    environ['wsgi.url_scheme'] = environ['HTTP_X_FORWARDED_PROTO']
+    environ['wsgi.url_scheme'] = environ.get('HTTP_X_FORWARDED_PROTO')
     environ['wsgi.input'] = StringIO(event['body'] or '')
     environ['wsgi.version'] = (1, 0)
     environ['wsgi.errors'] = sys.stderr


### PR DESCRIPTION
If the two headers HTTP_X_FORWARDED_PORT and HTTP_X_FORWARDED_PROTO don't exist in the event then an unrecoverable error is thrown. These are not default headers so we can't expect they will always be there.