### PR TITLE
remove import compatibility with older python versions

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -16,21 +16,10 @@
 
 import sys
 
-try:
-    from urllib import urlencode
-except ImportError:
-    from urllib.parse import urlencode
+from io import StringIO
+from urllib.parse import urlencode
 
 from flask import Flask
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    try:
-        from StringIO import StringIO
-    except ImportError:
-        from io import StringIO
-
 from werkzeug.wrappers import BaseRequest
 
 


### PR DESCRIPTION
because this package is intent to python3.6+, there is no need for import compatibity