### PR TITLE
fix: werkzeug 2.1.X support

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -20,7 +20,10 @@ from io import StringIO
 from urllib.parse import urlencode
 
 from flask import Flask
-from werkzeug.wrappers import BaseRequest
+try: # werkzeug <= 2.0.3
+    from werkzeug.wrappers import BaseRequest
+except: # werkzeug > 2.1
+    from werkzeug.wrappers import Request as BaseRequest
 
 
 __version__ = '0.0.4'


### PR DESCRIPTION
werkzeug 2.1.X support added to the repository for Flask 2.X onwards dependency 