### PR TITLE
Fix KeyError when 'body' not in event

### DIFF
--- a/flask_lambda.py
+++ b/flask_lambda.py
@@ -32,6 +32,11 @@ __version__ = '0.0.4'
 def make_environ(event):
     environ = {}
     print('event', event)
+
+    # fix issue where body is not present in the event
+    if 'body' not in event:
+      event['body'] = None
+
     # key might be there but set to None
     headers = event.get('headers', {}) or {}
     for hdr_name, hdr_value in headers.items():


### PR DESCRIPTION
Fix `KeyError` bug when the lambda event object doesn't contain a 'body' attribute